### PR TITLE
Labels Over Circles

### DIFF
--- a/March/src/components/overview/renderStarsNumber.js
+++ b/March/src/components/overview/renderStarsNumber.js
@@ -57,15 +57,19 @@ export function renderStarsNumber(selector, source) {
 					.outerRadius(function(d) { return (d.r + 10); })
 					.startAngle(Math.PI * 0.15);
 
-    const groups = nodes.filter(function(d) { return !!d.children; });
+    const groupLabels = container
+        			.selectAll(".group")
+    				.data(data.filter(function(d) { return !!d.children; })).enter()
+    				.append("g")
+      					.attr("transform", function(d) { return `translate(${d.x},${d.y})`; });
 
-	groups
+	groupLabels
 		.append("path")
 	  		.attr("class", "group-arc")
 			.attr("id", function(d,i) { return `arc${i}`; })
 			.attr("d", labelArc.endAngle(Math.PI * 0.77));
 
-	groups
+	groupLabels
 		.append("text")
 			.attr("class", "group-label")
 			.attr("x", 5) 


### PR DESCRIPTION
Very nice work! I noticed the labels were underneath some of the circles, and found a quick fix.

Before:

![image](https://user-images.githubusercontent.com/68416/38161281-d9a8166e-34e9-11e8-8949-12b2630ae693.png)

After:

![image](https://user-images.githubusercontent.com/68416/38161287-edafb09a-34e9-11e8-9e62-93c40139c385.png)
